### PR TITLE
pc - restore deleted file needed for TravisCI

### DIFF
--- a/test/run.sh
+++ b/test/run.sh
@@ -1,0 +1,10 @@
+#!/bin/sh
+
+mvn clean package
+ret=$?
+if [ $ret -ne 0 ]; then
+    exit $ret
+fi
+rm -rf target
+
+exit


### PR DESCRIPTION
The original source for this example at <https://github.com/spring-guides/gs-spring-boot> contained a file `/test/run.sh` that I had deleted because I didn't see it's purpose.

I know see that the `.travis.yml` file invokes this to run tests.

I've restored the file, but only the parts that deal with running Maven on the complete app.